### PR TITLE
Add error messages when pasted icon dimenions don't match DMI dimensions

### DIFF
--- a/media/editor/listView.tsx
+++ b/media/editor/listView.tsx
@@ -4,6 +4,8 @@ import { DmiState, Dirs, Dmi } from "../../shared/dmi";
 import { EditableField } from "./components";
 import { buildClassName, useGlobalHandler } from "./useHelpers";
 import Image from 'image-js';
+import { messageHandler, vscode } from "./state";
+import { MessageType } from "../../shared/messaging";
 
 type ListStateDisplayProps = {
 	state: DmiState;
@@ -111,6 +113,11 @@ export const StateList: React.FC<StateListProps> = (props) => {
 			if (prospectiveState.width == dmi.width && prospectiveState.height == dmi.height) {
 				imagesFromFiles.push({ image: prospectiveState, name : file.name});
 			}
+			else
+			{
+				// TODO: Just resize as needed
+				messageHandler.sendEvent({ type: MessageType.Alert, text: `Size of pasted image (${prospectiveState.width}x${prospectiveState.height}) does not match size of DMI (${dmi.width}x${dmi.height})` });
+			}
 		}
 		/// Next, actually try to read raw clipboard
 		let clipboardContents : ClipboardItems;
@@ -138,6 +145,11 @@ export const StateList: React.FC<StateListProps> = (props) => {
 					if(state.width == dmi.width && state.height == dmi.height){
 						addState(state);
 					}
+					else
+					{
+						// TODO: Just resize as needed
+						messageHandler.sendEvent({ type: MessageType.Alert, text: `Size of pasted image (${state.width}x${state.height}) does not match size of DMI (${dmi.width}x${dmi.height})` });
+					}
 					return; //We don't want to try to add png blobs since they always have less info than our direct data
 				}
 			}
@@ -153,6 +165,11 @@ export const StateList: React.FC<StateListProps> = (props) => {
 						for (const state of dmi_or_png.states) {
 							addState(state);
 						}
+					}
+					else
+					{
+						// TODO: Just resize as needed
+						messageHandler.sendEvent({ type: MessageType.Alert, text: `Size of pasted image (${dmi_or_png.width}x${dmi_or_png.height}) does not match size of DMI (${dmi.width}x${dmi.height})` });
 					}
 				} catch (error) {
 					// Parse failed so it's some mangled metadata, just give up

--- a/shared/messaging.ts
+++ b/shared/messaging.ts
@@ -4,7 +4,8 @@ export const enum MessageType{
 	ReadyRequest, //Webview finished initalizing, asking for data
 	ReadyResponse, //Responding with inital data
 	EditEvent, // Dmi edited on webview side
-	DocumentChangedEvent // Document changed externally
+	DocumentChangedEvent, // Document changed externally
+	Alert // Communicate with the user that something went wrong
 }
 
 
@@ -34,8 +35,13 @@ export interface DocumentChangedEventMessage {
 	serialized_dmi: string;
 }
 
+export interface AlertEventMessage {
+	type: MessageType.Alert;
+	text: string;
+}
+
 export type ToWebviewMessage = ReadyResponseMessage | DocumentChangedEventMessage
-export type FromWebviewMessage = ReadyRequestMessage | EditEventMessage
+export type FromWebviewMessage = ReadyRequestMessage | EditEventMessage | AlertEventMessage
 
 export type ExtensionHostMessageHandler = MessageHandler<ToWebviewMessage, FromWebviewMessage>;
 export type WebviewMessageHandler = MessageHandler<FromWebviewMessage, ToWebviewMessage>;

--- a/src/dmiEditor.ts
+++ b/src/dmiEditor.ts
@@ -267,6 +267,9 @@ export class DmiEditorProvider implements vscode.CustomEditorProvider<DmiDocumen
 			case MessageType.EditEvent:
 				await document.makeEdit(message.edited_dmi, false);
 				break;
+			case MessageType.Alert:
+				vscode.window.showErrorMessage(message.text);
+				break;
 		}
 	}
 


### PR DESCRIPTION
This PR simply adds an alert message type so that errors like a mismatched image dimensions can be communicated to the user.

We started using this extension recently, but spent a few hours trying to figure out why pasting icons wasn't working for someone only to find out that there is a check that the dimensions of the image being pasted must match the DMI's dimensions exactly (despite dreammaker more or less supporting this).

In the future it would probably be better to just support pasting both too small (either place bottom left like dreammaker does or scale up), and too large icons (just scale down) with warnings.

![image](https://user-images.githubusercontent.com/76988376/197435496-be901d0c-ea71-4fd1-bedc-2d6895112999.png)
