### PR TITLE
Fix delays being parsed as integers instead of floats

### DIFF
--- a/media/editor/detailView.tsx
+++ b/media/editor/detailView.tsx
@@ -82,7 +82,7 @@ export const StateDetailView: React.FC<StateDetailViewProps> = (props) => {
 		const value_as_number = parseFloat(new_value);
 		if(isNaN(value_as_number))
 			return;
-		const updatedDelays = filledDelays.map((value,index) => index == delay_index ? parseFloat(new_value) : value);
+		const updatedDelays = filledDelays.map((value,index) => index == delay_index ? Math.abs(parseFloat(new_value)) : value);
 		const new_state = props.state.clone();
 		new_state.delays = updatedDelays;
 		new_state.mark_dirty();

--- a/media/editor/detailView.tsx
+++ b/media/editor/detailView.tsx
@@ -79,10 +79,10 @@ export const StateDetailView: React.FC<StateDetailViewProps> = (props) => {
 	};
 
 	const updateDelay = (delay_index:number, new_value: string) => {
-		const value_as_number = parseInt(new_value);
+		const value_as_number = parseFloat(new_value);
 		if(isNaN(value_as_number))
 			return;
-		const updatedDelays = filledDelays.map((value,index) => index == delay_index ? parseInt(new_value) : value);
+		const updatedDelays = filledDelays.map((value,index) => index == delay_index ? parseFloat(new_value) : value);
 		const new_state = props.state.clone();
 		new_state.delays = updatedDelays;
 		new_state.mark_dirty();


### PR DESCRIPTION
This PR allows delays to both be assigned and read as floats rather than integers. Also fixes entering a negative delay.

From dreammaker: 
![image](https://user-images.githubusercontent.com/76988376/201523370-e8369f04-5e81-4471-81d4-3fb12005c973.png)